### PR TITLE
Microsoft.Extensions.Configuration.Binderを8.0.0-preview.7.23375.6に戻す

### DIFF
--- a/Source/GitHubSettingsSync.Models.Abstractions/EnvironmentVariables.cs
+++ b/Source/GitHubSettingsSync.Models.Abstractions/EnvironmentVariables.cs
@@ -9,21 +9,17 @@ namespace GitHubSettingsSync.Models;
 public sealed record EnvironmentVariables
 {
     /// <summary>
-    /// <see cref="EnvironmentVariables"/>クラスの新しいインスタンスを初期化します。
-    /// </summary>
-    public EnvironmentVariables()
-    {
-    }
-
-    /// <summary>
     /// トークンを取得または設定します。
     /// </summary>
     /// <value>
     /// GitHubの個人用アクセストークンを返します。
     /// </value>
+    /// <remarks>
+    /// initアクセサにするとソースジェネレーター使用時、バインドされないので注意する。
+    /// </remarks>
     [Required]
     [ConfigurationKeyName("GITHUB_TOKEN")]
-    public required string GitHubToken { get; init; }
+    public required string GitHubToken { get; set; }
 
     /// <summary>
     /// GitHub APIのURLを取得または設定します。
@@ -31,8 +27,11 @@ public sealed record EnvironmentVariables
     /// <value>
     /// 「GITHUB_API_URL」環境変数を返します。
     /// </value>
+    /// <remarks>
+    /// initアクセサにするとソースジェネレーター使用時、バインドされないので注意する。
+    /// </remarks>
     [ConfigurationKeyName("GITHUB_API_URL")]
-    public string? GitHubApiUrl { get; init; }
+    public string? GitHubApiUrl { get; set; }
 
     /// <summary>
     /// GitHubオーナー名を取得または設定します。
@@ -40,6 +39,9 @@ public sealed record EnvironmentVariables
     /// <value>
     /// 「GITHUB_REPOSITORY_OWNER」環境変数を返します。
     /// </value>
+    /// <remarks>
+    /// initアクセサにするとソースジェネレーター使用時、バインドされないので注意する。
+    /// </remarks>
     [ConfigurationKeyName("GITHUB_REPOSITORY_OWNER")]
-    public string? GitHubRepositoryOwner { get; init; }
+    public string? GitHubRepositoryOwner { get; set; }
 }

--- a/Source/GitHubSettingsSync/GitHubSettingsSync.csproj
+++ b/Source/GitHubSettingsSync/GitHubSettingsSync.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <!--<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>-->
     <Aot>true</Aot>
     <EnableReflection>true</EnableReflection>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="ConsoleAppFramework" Version="4.2.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-rc.1.23419.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-preview.7.23375.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0-preview.7.23375.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/GitHubSettingsSync/Program.cs
+++ b/Source/GitHubSettingsSync/Program.cs
@@ -23,11 +23,7 @@ var builder = ConsoleApp.CreateBuilder(args)
     })
     .ConfigureServices(static (context, services) =>
     {
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-#pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
         services.Configure<EnvironmentVariables>(context.Configuration);
-#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
         services.AddSingleton<IValidateOptions<EnvironmentVariables>, EnvironmentVariablesValidator>();
 
         services.AddHttpClient<IGitHubClient, GitHubClient>(static (provider, client) =>


### PR DESCRIPTION
Microsoft.Extensions.Configuration.Binder (8.0.0-rc.1) 同梱のConfiguration Binding Generatorには不具合があり、コンパイルエラーとなる。
8.0.0-rc.2以降のバージョンにすると解決するが、デイリービルドを使いたくないため、8.0.0-preview.7.23375.6に戻す。